### PR TITLE
Add S3 sync automation from master branch on any change to the repo.

### DIFF
--- a/.github/workflows/push-to-master.yaml
+++ b/.github/workflows/push-to-master.yaml
@@ -1,0 +1,22 @@
+name: S3 CD
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  sync_s3:
+    name: Sync to S3
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --delete
+        env:
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        SOURCE_DIR: './AutoStack/ec2'
+        DEST_DIR: 'scripts'


### PR DESCRIPTION
Resolves #40 

Adds a new workflow for syncing files from ./AutoStack/ec2 to s3://bucket-name/scripts.

An AWS user with restricted permissions has been created for this workflow, and it's credentials are encrypted in the repo's GitHub secrets.

If we want to extend this (to include lambda functions, public site, CloudFormation scripts, etc), we just need more jobs in the workflow file. Additionally, we will need to extend permissions to the AWS user.